### PR TITLE
Fix file retrieval and filtering in retrieve_filelist.R

### DIFF
--- a/R/retrieve_filelist.R
+++ b/R/retrieve_filelist.R
@@ -42,8 +42,22 @@ retrieve_filelist <- function(database,
   all_files_string <- RCurl::getURL(FTP_URL, dirlistonly = TRUE)
   all_files_list <- strsplit(all_files_string, "\r\n")[[1]]
 
+
+    all_files_list   <- strsplit(all_files_string, "\n")[[1]]
+  all_files_list   <- trimws(gsub("\r", "", all_files_list))  # remove CR & spaces
+  all_files_list   <- all_files_list[nzchar(all_files_list)]  # remove empty
+  
+  # filter DB (default SIASUS: {DB}{UF}{YYMM}.dbc)
+  selected_files <- grep(
+    sprintf("^%s[A-Z]{2}\\d{4}\\.dbc$", toupper(database)),
+    all_files_list,
+    value = TRUE
+  )
+
+
+  
   # Filter only the selected database if the name starts with database
-  selected_files <- all_files_list[grepl(paste0("^", database), all_files_list)]
+  #selected_files <- all_files_list[grepl(paste0("^", database), all_files_list)]
 
   # Filter only the specified years - Filename pattern: '{DB}{FU}{YYMM}.dbc'
   selected_files <- selected_files[sapply(selected_files, function(x)


### PR DESCRIPTION
Updated the file retrieval logic to handle different line endings and added filtering for specific database files.

The line:
selected_files <- all_files_list[grepl(paste0("^", database), all_files_list)]

raise the error:
Error in selected_files[sapply(selected_files, function(x) as.numeric(substring(x,  : 
  invalid subscript type 'list'
  
This happens on linux based system.
Already tested the new code on Windows and Linux and works fine.